### PR TITLE
Don't panic when a value isn't send in a GetPropertyReply, instead use the default value

### DIFF
--- a/src/ewmh/proto/application_props.rs
+++ b/src/ewmh/proto/application_props.rs
@@ -22,7 +22,7 @@ pub struct GetWmNameReply {
 impl From<xcb::x::GetPropertyReply> for GetWmNameReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetWmNameReply {
-            name: x_buffer_to_strings(reply.value::<u8>())[0].to_owned(),
+            name: x_buffer_string_or_default!(reply),
         }
     }
 }
@@ -44,7 +44,7 @@ pub struct SetWmName {
 impl SetWmName {
     pub fn new(window: xcb::x::Window, name: &str) -> SetWmName {
         SetWmName {
-            window: window,
+            window,
             data: strings_to_x_buffer(vec![name]),
         }
     }
@@ -70,7 +70,7 @@ pub struct GetWmVisibleNameReply {
 impl From<xcb::x::GetPropertyReply> for GetWmVisibleNameReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetWmVisibleNameReply {
-            name: x_buffer_to_strings(reply.value::<u8>())[0].to_owned(),
+            name: x_buffer_string_or_default!(reply),
         }
     }
 }
@@ -95,7 +95,7 @@ pub struct GetWmIconNameReply {
 impl From<xcb::x::GetPropertyReply> for GetWmIconNameReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetWmIconNameReply {
-            name: x_buffer_to_strings(reply.value::<u8>())[0].to_owned(),
+            name: x_buffer_string_or_default!(reply),
         }
     }
 }
@@ -120,7 +120,7 @@ pub struct GetWmVisibleIconNameReply {
 impl From<xcb::x::GetPropertyReply> for GetWmVisibleIconNameReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetWmVisibleIconNameReply {
-            name: x_buffer_to_strings(reply.value::<u8>())[0].to_owned(),
+            name: x_buffer_string_or_default!(reply),
         }
     }
 }
@@ -145,7 +145,7 @@ pub struct GetWmDesktopReply {
 impl From<xcb::x::GetPropertyReply> for GetWmDesktopReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetWmDesktopReply {
-            desktop: reply.value::<u32>()[0],
+            desktop: nth_u32_value_or_default!(reply, 0),
         }
     }
 }
@@ -167,7 +167,7 @@ pub struct SetWmDesktop {
 impl SetWmDesktop {
     pub fn new(window: xcb::x::Window, desktop: u32) -> SetWmDesktop {
         SetWmDesktop {
-            window: window,
+            window,
             data: vec![desktop],
         }
     }

--- a/src/ewmh/proto/macros/mod.rs
+++ b/src/ewmh/proto/macros/mod.rs
@@ -6,3 +6,20 @@ mod set_property;
 
 #[macro_use]
 mod client_message;
+
+macro_rules! x_buffer_string_or_default {
+    ($reply:expr) => {{
+        x_buffer_to_strings($reply.value::<u8>())
+            .first()
+            .map_or_else(Default::default, ToOwned::to_owned)
+    }};
+}
+
+macro_rules! nth_u32_value_or_default {
+    ($reply:expr, $index:expr) => {{
+        $reply
+            .value::<u32>()
+            .get($index)
+            .map_or_else(Default::default, ToOwned::to_owned)
+    }};
+}

--- a/src/ewmh/proto/root_props.rs
+++ b/src/ewmh/proto/root_props.rs
@@ -95,7 +95,7 @@ pub struct GetNumberOfDesktopsReply {
 impl From<xcb::x::GetPropertyReply> for GetNumberOfDesktopsReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetNumberOfDesktopsReply {
-            desktops: reply.value::<u32>()[0],
+            desktops: nth_u32_value_or_default!(reply, 0),
         }
     }
 }
@@ -141,8 +141,8 @@ pub struct GetDesktopGeometryReply {
 impl From<xcb::x::GetPropertyReply> for GetDesktopGeometryReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetDesktopGeometryReply {
-            width: reply.value::<u32>()[0],
-            height: reply.value::<u32>()[1],
+            width: nth_u32_value_or_default!(reply, 0),
+            height: nth_u32_value_or_default!(reply, 1),
         }
     }
 }
@@ -188,8 +188,8 @@ pub struct GetDesktopViewportReply {
 impl From<xcb::x::GetPropertyReply> for GetDesktopViewportReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetDesktopViewportReply {
-            x: reply.value::<u32>()[0],
-            y: reply.value::<u32>()[1],
+            x: nth_u32_value_or_default!(reply, 0),
+            y: nth_u32_value_or_default!(reply, 1),
         }
     }
 }
@@ -234,7 +234,7 @@ pub struct GetCurrentDesktopReply {
 impl From<xcb::x::GetPropertyReply> for GetCurrentDesktopReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetCurrentDesktopReply {
-            desktop: reply.value::<u32>()[0],
+            desktop: nth_u32_value_or_default!(reply, 0),
         }
     }
 }
@@ -324,7 +324,7 @@ pub struct GetActiveWindowReply {
 impl From<xcb::x::GetPropertyReply> for GetActiveWindowReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetActiveWindowReply {
-            window: unsafe { xcb::x::Window::new(reply.value::<u32>()[0]) },
+            window: unsafe { xcb::x::Window::new(nth_u32_value_or_default!(reply, 0)) },
         }
     }
 }
@@ -384,10 +384,10 @@ pub struct GetWorkareaReply {
 impl From<xcb::x::GetPropertyReply> for GetWorkareaReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetWorkareaReply {
-            x: reply.value::<u32>()[0],
-            y: reply.value::<u32>()[1],
-            width: reply.value::<u32>()[2],
-            height: reply.value::<u32>()[3],
+            x: nth_u32_value_or_default!(reply, 0),
+            y: nth_u32_value_or_default!(reply, 1),
+            width: nth_u32_value_or_default!(reply, 2),
+            height: nth_u32_value_or_default!(reply, 3),
         }
     }
 }
@@ -412,7 +412,7 @@ pub struct GetSupportingWmCheckReply {
 impl From<xcb::x::GetPropertyReply> for GetSupportingWmCheckReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetSupportingWmCheckReply {
-            window: unsafe { xcb::x::Window::new(reply.value::<u32>()[0]) },
+            window: unsafe { xcb::x::Window::new(nth_u32_value_or_default!(reply, 0)) },
         }
     }
 }
@@ -437,7 +437,7 @@ pub struct GetVirtualRootsReply {
 impl From<xcb::x::GetPropertyReply> for GetVirtualRootsReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetVirtualRootsReply {
-            window: unsafe { xcb::x::Window::new(reply.value::<u32>()[0]) },
+            window: unsafe { xcb::x::Window::new(nth_u32_value_or_default!(reply, 0)) },
         }
     }
 }
@@ -465,10 +465,10 @@ pub struct DesktopLayoutReply {
 impl From<xcb::x::GetPropertyReply> for DesktopLayoutReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         DesktopLayoutReply {
-            orientation: reply.value::<u32>()[0],
-            columns: reply.value::<u32>()[1],
-            rows: reply.value::<u32>()[2],
-            starting_corner: reply.value::<u32>()[3],
+            orientation: nth_u32_value_or_default!(reply, 0),
+            columns: nth_u32_value_or_default!(reply, 1),
+            rows: nth_u32_value_or_default!(reply, 2),
+            starting_corner: nth_u32_value_or_default!(reply, 3),
         }
     }
 }
@@ -493,7 +493,7 @@ pub struct GetShowingDesktopReply {
 impl From<xcb::x::GetPropertyReply> for GetShowingDesktopReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetShowingDesktopReply {
-            is_showing_desktop: { reply.value::<u32>()[0] == 1 },
+            is_showing_desktop: { nth_u32_value_or_default!(reply, 0) == 1 },
         }
     }
 }

--- a/src/icccm/proto/client_props.rs
+++ b/src/icccm/proto/client_props.rs
@@ -5,8 +5,6 @@
 #![allow(dead_code)]
 
 use bitflags::bitflags;
-use std::convert::TryInto;
-use std::io::BufRead;
 use std::mem;
 use xcb::{Xid, XidNew};
 
@@ -27,7 +25,7 @@ impl From<xcb::x::GetPropertyReply> for GetWmNameReply {
         let x = reply.value::<u8>().into();
         GetWmNameReply {
             // TODO Compound string
-            name: String::from_utf8(x).unwrap(),
+            name: String::from_utf8(x).unwrap_or_default(),
         }
     }
 }
@@ -50,8 +48,8 @@ pub struct SetWmName<T: xcb::x::PropEl> {
 impl<T: xcb::x::PropEl> SetWmName<T> {
     pub fn new(window: xcb::x::Window, encoding: xcb::x::Atom, name: Vec<T>) -> SetWmName<T> {
         SetWmName {
-            window: window,
-            encoding: encoding,
+            window,
+            encoding,
             data: name,
         }
     }
@@ -76,7 +74,7 @@ impl From<xcb::x::GetPropertyReply> for GetWmIconNameReply {
         let x = reply.value::<u8>().into();
         GetWmIconNameReply {
             // TODO Compound string
-            name: String::from_utf8(x).unwrap(),
+            name: String::from_utf8(x).unwrap_or_default(),
         }
     }
 }
@@ -99,8 +97,8 @@ pub struct SetWmIconName<T: xcb::x::PropEl> {
 impl<T: xcb::x::PropEl> SetWmIconName<T> {
     pub fn new(window: xcb::x::Window, encoding: xcb::x::Atom, name: Vec<T>) -> SetWmIconName<T> {
         SetWmIconName {
-            window: window,
-            encoding: encoding,
+            window,
+            encoding,
             data: name,
         }
     }
@@ -148,7 +146,7 @@ impl SetWmColorMapWindows {
         colormap_windows: Vec<xcb::x::Window>,
     ) -> SetWmColorMapWindows {
         SetWmColorMapWindows {
-            window: window,
+            window,
             data: colormap_windows,
         }
     }
@@ -174,7 +172,7 @@ impl From<xcb::x::GetPropertyReply> for GetWmClientMachineReply {
         let x = reply.value::<u8>().into();
         GetWmClientMachineReply {
             // TODO Compound string
-            name: String::from_utf8(x).unwrap(),
+            name: String::from_utf8(x).unwrap_or_default(),
         }
     }
 }
@@ -201,8 +199,8 @@ impl<T: xcb::x::PropEl> SetWmClientMachine<T> {
         name: Vec<T>,
     ) -> SetWmClientMachine<T> {
         SetWmClientMachine {
-            window: window,
-            encoding: encoding,
+            window,
+            encoding,
             data: name,
         }
     }
@@ -225,7 +223,7 @@ pub struct GetWmClassReply {
 
 impl From<xcb::x::GetPropertyReply> for GetWmClassReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
-        let values: Vec<&[u8]> = reply.value::<u8>().split(|v| *v == 0x00 as u8).collect();
+        let values: Vec<&[u8]> = reply.value::<u8>().split(|v| *v == 0x00_u8).collect();
 
         GetWmClassReply {
             instance: String::from_utf8_lossy(values[0]).to_string(),
@@ -253,14 +251,11 @@ impl SetWmClass {
     pub fn new(window: xcb::x::Window, instance: &str, class: &str) -> SetWmClass {
         let mut data = vec![];
         data.append(&mut instance.as_bytes().to_vec());
-        data.push(0x00 as u8);
+        data.push(0x00_u8);
         data.append(&mut class.as_bytes().to_vec());
-        data.push(0x00 as u8);
+        data.push(0x00_u8);
 
-        SetWmClass {
-            window: window,
-            data: data,
-        }
+        SetWmClass { window, data }
     }
 }
 
@@ -282,7 +277,14 @@ pub struct GetWmTransientForReply {
 impl From<xcb::x::GetPropertyReply> for GetWmTransientForReply {
     fn from(reply: xcb::x::GetPropertyReply) -> Self {
         GetWmTransientForReply {
-            window: unsafe { xcb::x::Window::new(reply.value::<u32>()[0]) },
+            window: unsafe {
+                xcb::x::Window::new(
+                    reply
+                        .value::<u32>()
+                        .first()
+                        .map_or_else(Default::default, ToOwned::to_owned),
+                )
+            },
         }
     }
 }
@@ -305,7 +307,7 @@ impl SetWmTransientFor {
     // TODO better name for second window
     pub fn new(window: xcb::x::Window, window2: xcb::x::Window) -> SetWmTransientFor {
         SetWmTransientFor {
-            window: window,
+            window,
             data: vec![window2],
         }
     }
@@ -527,7 +529,7 @@ pub struct SetWmNormalHints {
 impl SetWmNormalHints {
     pub fn new(window: xcb::x::Window, size_hints: &mut WmSizeHints) -> SetWmNormalHints {
         SetWmNormalHints {
-            window: window,
+            window,
             data: size_hints.as_data(),
         }
     }
@@ -629,9 +631,9 @@ impl WmHints {
         };
 
         WmHints {
-            flags: flags,
+            flags,
             input: packed_vals[1] != 0,
-            initial_state: initial_state,
+            initial_state,
             icon_pixmap: unsafe { xcb::x::Pixmap::new(packed_vals[3]) },
             icon_window: unsafe { xcb::x::Window::new(packed_vals[4]) },
             icon_x: packed_vals[5],
@@ -717,7 +719,7 @@ pub struct SetWmHints {
 impl SetWmHints {
     pub fn new(window: xcb::x::Window, hints: &mut WmHints) -> SetWmHints {
         SetWmHints {
-            window: window,
+            window,
             data: hints.as_data(),
         }
     }


### PR DESCRIPTION
I had quite a few panics, mostly when accessing something like `name` (IconName or WindowName). I don't think it's a good practice to just panic there, as it kind of seems to be allowed that parameters are sometimes optional.
I'm not sure which parameter is really optional, so also to not change the API I'll just use default values, it almost always still makes sense (empty name, or width/height == 0).

Also applied a few clippy lints on the way...